### PR TITLE
Find HDF5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,9 @@ if (OPENMP_FOUND)
 	set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 endif()
 
+# HDF5
+find_package(HDF5 REQUIRED)
+
 # Eigen
 include_directories(lib/3rdParty/Eigen)
 


### PR DESCRIPTION
This avoids an HDF5 error while compiling the program on Ubuntu 16.04 LTS.
https://cmake.org/cmake/help/latest/module/FindHDF5.html