### PR TITLE
Clarify Extreme 3D folder and not dlib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ Note that we modified the model files from the 3DMM-CNN paper. Therefore, if you
 ```
 	(http://dlib.net/)
 ```
-- Update Dlib directory paths (`DLIB_INCLUDE_DIR` and `DLIB_LIB_DIR`) in `CMakeLists.txt`
-- Make build directory (temporary). Make & install to bin folder
+- In Extreme 3D's `CMakeLists.txt`, update Dlib directory paths (`DLIB_INCLUDE_DIR` and `DLIB_LIB_DIR`).
+- Make build directory (temporary) in the Extreme 3D downloaded repository. Make & install to bin folder
 ```
 	mkdir build
 	cd build


### PR DESCRIPTION
After the dlib installation bullet point, this makes it clearer to update the dlib directory paths, make the build directory, etc. in the downloaded Extreme 3D repository, not the dlib folder.