### PR TITLE
reorder docker ADD to leverage caching, fix python dlib build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
 FROM mxnet/python:1.1.0_nccl
-WORKDIR /app
-ADD . /app
 
 RUN apt-get update
 RUN apt-get install -y libhdf5-serial-dev libboost-all-dev nano cmake libosmesa6-dev freeglut3-dev
@@ -13,10 +11,14 @@ RUN wget http://dlib.net/files/dlib-19.6.tar.bz2; \
 	cmake ..; \
 	cmake --build . --config Release; \
 	make install; \
-	cd ..
+	cd ..; \
+	python setup.py install --yes USE_AVX_INSTRUCTIONS --yes DLIB_USE_CUDA
 
 RUN pip install http://download.pytorch.org/whl/cu90/torch-0.3.1-cp27-cp27mu-linux_x86_64.whl
-RUN pip install opencv-python torchvision==0.2.1 scikit-image cvbase pandas mmdnn dlib
+RUN pip install opencv-python torchvision==0.2.1 scikit-image cvbase pandas mmdnn
+
+WORKDIR /app
+ADD . /app
 
 RUN mkdir build; \
 	cd build; \


### PR DESCRIPTION
* [x] postpone as much as possible `ADD ./app` to preserve docker layer caching
* [x] build python binding of `dlib` from source (the same used for the c++ part) to fix broken `pip install dlib`

NOTE: it build `dlib` twice but it was basically doing this already